### PR TITLE
Lookup dimension filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,11 +181,11 @@ adds a $lookup to the query pipeline as
 ```
 {$lookup:{from:"countries",localField:"country",foreignField:"_id",as:"country}}
 {$unwind:"country"}
-{$project:{"country.name":"name"}}
+{$project:{"country.name":"$name"}}
 ```
 The first parameter given in the parens is the collection name. The one or more following parameters are
 included as dimensions.
->*NOTE:* Lookup qualifiers is not yet fully implemented
+>*NOTE:* Lookup qualifiers are not yet fully implemented
 
 
 ### Pull examples

--- a/handlers/Pull.mjs
+++ b/handlers/Pull.mjs
@@ -87,7 +87,7 @@ export default class Pull {
             statement = statement.concat(dp.expandDerivedFields());
 
             // add any filters built into the dimensions request
-            if (Object.keys(dp.filters).length > 0) statement.push({$match:dp.filters});
+            for (let filter of dp.filters) statement.push(filter);
             // group by metrics
             let group = {_id: {}};
             let project = {_id: 0, '_ns': '$_id._ns'};


### PR DESCRIPTION
Before being released, attribute security needs to be introduced. Note that this update changes the filters to be chained in the pipeline rather than gathered into one $match block using $and. Should have the same results.